### PR TITLE
Fixed unix start and stop scripts.

### DIFF
--- a/modules/x-gsn/gsn-start.sh
+++ b/modules/x-gsn/gsn-start.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-for jarFile in $( ls target/*jar ); do
+for jarFile in $( find -name "*.jar" ); do
      cp=$cp:./$jarFile
 done
-$JAVA_HOME/bin/java -classpath $cp -splash:lib/logo.png -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.Log4JLogger -Dorg.mortbay.log.LogFactory.noDiscovery=false gsn.Main 22232 &
 
-        
+java -classpath $cp -splash:lib/logo.png -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.Log4JLogger -Dorg.mortbay.log.LogFactory.noDiscovery=false org.openiot.gsn.Main 22232 &

--- a/modules/x-gsn/gsn-stop.sh
+++ b/modules/x-gsn/gsn-stop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-for jarFile in $( ls target/*jar ); do
+for jarFile in $( find -name "*.jar" ); do
      cp=$cp:./$jarFile
 done
-#$JAVA_HOME/bin/java -classpath $cp -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.Log4JLogger -Dorg.mortbay.log.LogFactory.noDiscovery=false gsn.GSNStop 22232         
-java -classpath $cp -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.Log4JLogger -Dorg.mortbay.log.LogFactory.noDiscovery=false gsn.GSNStop 22232         
+
+java -classpath $cp -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.Log4JLogger -Dorg.mortbay.log.LogFactory.noDiscovery=false org.openiot.gsn.GSNStop 22232


### PR DESCRIPTION
The unix start and stop scripts didn't properly add all jars to the classpath, and contained the wrong class name (missing org.openiot.)
