### PR TITLE
Updated CSVHandler

### DIFF
--- a/modules/x-gsn/src/main/java/org/openiot/gsn/wrappers/general/CSVWrapper.java
+++ b/modules/x-gsn/src/main/java/org/openiot/gsn/wrappers/general/CSVWrapper.java
@@ -50,6 +50,11 @@ public class CSVWrapper extends AbstractWrapper {
     private CSVHandler handler = new CSVHandler();
 
     private int samplingPeriodInMsc;
+	/**
+	 * The maximum number of samples to read from the file per sampling
+	 * period.
+	 */
+	private int samplingCountPerPeriod;
 
     private String checkPointDir;
 
@@ -74,6 +79,7 @@ public class CSVWrapper extends AbstractWrapper {
         String nullValues = addressBean.getPredicateValueWithDefault("bad-values", "");
         String strUseCounterForCheckPoint = addressBean.getPredicateValueWithDefault("use-counter-for-check-point", "false");
         samplingPeriodInMsc = addressBean.getPredicateValueAsInt("sampling", 10000);
+        samplingCountPerPeriod = addressBean.getPredicateValueAsInt("sampling-count", 250);
 
         /*
         DEBUG_INFO(dataFile);
@@ -157,7 +163,7 @@ public class CSVWrapper extends AbstractWrapper {
                 if (preivousError == null || (preivousError != null && ((lastModified != previousModTime || lastModifiedCheckPoint != previousCheckModTime) || useCounterForCheckPoint))) {
 
                     reader = new FileReader(handler.getDataFile());
-                    output = handler.work(reader, checkPointDir);
+                    output = handler.work(reader, checkPointDir, samplingCountPerPeriod);
                     for (TreeMap<String, Serializable> se : output) {
                         StreamElement streamElement = new StreamElement(se, getOutputFormat());
                         processedLineCounter++;

--- a/modules/x-gsn/src/main/java/org/openiot/gsn/wrappers/general/CSVWrapperTest.java
+++ b/modules/x-gsn/src/main/java/org/openiot/gsn/wrappers/general/CSVWrapperTest.java
@@ -127,27 +127,27 @@ public class CSVWrapperTest {
 		"01.01.2009,3,10:12,12,\"Ali Salehi\"\n";
 		CSVHandler wrapper = new CSVHandler();
 		assertEquals(true,wrapper.initialize("test.csv.csv", fields,formats,',','\"',0,"NaN,-1234,4321"));
-		ArrayList<TreeMap<String, Serializable>> parsed = wrapper.parseValues(new StringReader(data), -1);
+		ArrayList<TreeMap<String, Serializable>> parsed = wrapper.parseValues(new StringReader(data), -1, 250);
 		assertEquals(3, parsed.size());
-		assertEquals(wrapper.work(new StringReader(data), CHECK_POINT_DIR).size(), parsed.size());
+		assertEquals(wrapper.work(new StringReader(data), CHECK_POINT_DIR, 250).size(), parsed.size());
 		assertEquals(true,((Long)parsed.get(0).get("timed"))<((Long)parsed.get(1).get("timed")));
 		long recentTimestamp = ((Long)parsed.get(parsed.size()-1).get("timed"));
 		data+="01.01.2009,3,10:12,12,\"Ali Salehi\"\n";
-		assertEquals(0,wrapper.parseValues(new StringReader(data), recentTimestamp).size());
-		assertEquals(0,wrapper.work(new StringReader(data), CHECK_POINT_DIR).size());
+		assertEquals(0,wrapper.parseValues(new StringReader(data), recentTimestamp, 250).size());
+		assertEquals(0,wrapper.work(new StringReader(data), CHECK_POINT_DIR, 250).size());
 		
 		data+="01.01.2009,3,10:12,12,\"Ali Salehi\"\n";
 		data+="01.01.2009,3,10:11,12,\"Ali Salehi\"\n";
 		data+="01.01.2009,3,10:10,12,\"Ali Salehi\"\n";
-		assertEquals(0,wrapper.parseValues(new StringReader(data), recentTimestamp).size());
-		assertEquals(0,wrapper.work(new StringReader(data), CHECK_POINT_DIR).size());
+		assertEquals(0,wrapper.parseValues(new StringReader(data), recentTimestamp, 250).size());
+		assertEquals(0,wrapper.work(new StringReader(data), CHECK_POINT_DIR, 250).size());
 		data+="01.01.2009,3,10:13,13,\"Ali Salehi\"\n";
-		assertEquals(1,wrapper.parseValues(new StringReader(data), recentTimestamp).size());
-		assertEquals(1,wrapper.work(new StringReader(data), CHECK_POINT_DIR).size());
+		assertEquals(1,wrapper.parseValues(new StringReader(data), recentTimestamp, 250).size());
+		assertEquals(1,wrapper.work(new StringReader(data), CHECK_POINT_DIR, 250).size());
 		data="###########################\n\n\n\n,,,,,,,,,\n\n\n"; // Empty File.
 		wrapper.setSkipFirstXLines(1);
-		assertEquals(0,wrapper.parseValues(new StringReader(data), recentTimestamp).size());
-		assertEquals(0,wrapper.work(new StringReader(data), CHECK_POINT_DIR).size());
+		assertEquals(0,wrapper.parseValues(new StringReader(data), recentTimestamp, 250).size());
+		assertEquals(0,wrapper.work(new StringReader(data), CHECK_POINT_DIR, 250).size());
 		
 	}
 	


### PR DESCRIPTION
- Updated CSVHandler to make sample-count-per-period configurable (was fixed at 250).
- Updated CSVHandler to fix possible missed samples with the same timestamp.

CSVHandler used the timestamp of the last sample as a check for the next run. Thus, if there were multiple samples with the same timestamp and the count-limit was reached after the first, the other samples would be skipped at the next run. This fix should make it that if there are multiple samples with the same timestamp, they are all read regardless of the count-limit.
